### PR TITLE
Use NoopSpan for new traces

### DIFF
--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -130,8 +130,6 @@ class Tracer implements API\Tracer
             ? $this->getActiveSpan()->getContext()
             : SpanContext::generate(true);
 
-        $this->setActiveSpan($parent);
-
         $context = SpanContext::fork($parent->getTraceId(), $parent->isSampled());
         $span = $this->generateSpanInstance($name, $context);
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -24,6 +24,7 @@ class Tracer implements API\Tracer
     private $resource;
 
     private $rootContext;
+    private $rootSpan;
 
     public function __construct(
         TracerProvider $provider,
@@ -32,13 +33,15 @@ class Tracer implements API\Tracer
     ) {
         $this->provider = $provider;
         $this->resource = $resource;
+        $this->rootSpan = new NoopSpan();
+        $this->setActiveSpan($this->rootSpan);
         $this->rootContext = $context ? $context : SpanContext::generate(true);
     }
 
     /**
      * @return Span
      */
-    public function getActiveSpan(): ?API\Span
+    public function getActiveSpan(): API\Span
     {
         while (count($this->tail) && $this->active->getEnd()) {
             $this->active = array_pop($this->tail);

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -130,6 +130,8 @@ class Tracer implements API\Tracer
             ? $this->getActiveSpan()->getContext()
             : SpanContext::generate(true);
 
+        $this->setActiveSpan($parent);
+
         $context = SpanContext::fork($parent->getTraceId(), $parent->isSampled());
         $span = $this->generateSpanInstance($name, $context);
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -23,8 +23,6 @@ class Tracer implements API\Tracer
      */
     private $resource;
 
-    private $rootSpan;
-
     public function __construct(
         TracerProvider $provider,
         ResourceInfo $resource,
@@ -32,8 +30,7 @@ class Tracer implements API\Tracer
     ) {
         $this->provider = $provider;
         $this->resource = $resource;
-        $this->rootSpan = new NoopSpan();
-        $this->setActiveSpan($this->rootSpan);
+        $this->setActiveSpan(new NoopSpan());
     }
 
     /**

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -41,9 +41,7 @@ class Tracer implements API\Tracer
      */
     public function getActiveSpan(): API\Span
     {
-        // While elements in tail array and active span has finished
         while (count($this->tail) && $this->active->getEnd()) {
-            // Set active to the last item of array, and remove item from array, may be null if array is empty
             $this->active = array_pop($this->tail);
         }
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -16,11 +16,11 @@ class Tracer implements API\Tracer
     /**
      * @var TracerProvider $provider OpenTelemetry Tracer provider
      * @var ResourceInfo $resource Resource Info
-     * @var API\SpanContext $parentContext Parent context
+     * @var API\SpanContext $importedContext Context imported from an external system
      */
     private $provider;
     private $resource;
-    private $parentContext;
+    private $importedContext;
 
     public function __construct(
         TracerProvider $provider,
@@ -29,7 +29,7 @@ class Tracer implements API\Tracer
     ) {
         $this->provider = $provider;
         $this->resource = $resource;
-        $this->parentContext = $context;
+        $this->importedContext = $context;
     }
 
     /**
@@ -129,7 +129,7 @@ class Tracer implements API\Tracer
         $parentContextIsNoopSpan = !$parentContext->isValidContext();
         
         if ($parentContextIsNoopSpan) {
-            $parentContext = $this->parentContext ?? SpanContext::generate(true);
+            $parentContext = $this->importedContext ?? SpanContext::generate(true);
         }
 
         $context = SpanContext::fork($parentContext->getTraceId(), $parentContext->isSampled());

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -30,7 +30,6 @@ class Tracer implements API\Tracer
     ) {
         $this->provider = $provider;
         $this->resource = $resource;
-        $this->setActiveSpan(new NoopSpan());
     }
 
     /**
@@ -42,7 +41,7 @@ class Tracer implements API\Tracer
             $this->active = array_pop($this->tail);
         }
 
-        return $this->active;
+        return $this->active ?? new NoopSpan();
     }
 
     public function setActiveSpan(API\Span $span): void
@@ -166,6 +165,7 @@ class Tracer implements API\Tracer
         if ($this->active) {
             $parent = $this->getActiveSpan()->getContext();
         }
+        
         $span = new Span($name, $context, $parent);
         $this->spans[] = $span;
 

--- a/sdk/Trace/Tracer.php
+++ b/sdk/Trace/Tracer.php
@@ -126,7 +126,9 @@ class Tracer implements API\Tracer
     public function startAndActivateSpan(string $name): API\Span
     {
         $parentContext = $this->getActiveSpan()->getContext();
-        if (!$parentContext->isValidContext()) {
+        $parentContextIsNoopSpan = !$parentContext->isValidContext();
+        
+        if ($parentContextIsNoopSpan) {
             $parentContext = $this->parentContext ?? SpanContext::generate(true);
         }
 
@@ -141,7 +143,7 @@ class Tracer implements API\Tracer
 
         return $this->active;
     }
-    
+
     public function getSpans(): array
     {
         return $this->spans;

--- a/tests/Sdk/Unit/Trace/TracingTest.php
+++ b/tests/Sdk/Unit/Trace/TracingTest.php
@@ -44,7 +44,10 @@ class TracingTest extends TestCase
         $tracer2 = new Tracer($tracerProvider, ResourceInfo::create(new Attributes([])), $spanContext2);
         $tracer2->startAndActivateSpan('tracer2.firstSpan');
 
-        $this->assertSame($tracer->getActiveSpan()->getContext()->getTraceId(), $tracer2->getActiveSpan()->getContext()->getTraceId());
+        $this->assertSame(
+            $tracer->getActiveSpan()->getContext()->getTraceId(),
+            $tracer2->getActiveSpan()->getContext()->getTraceId()
+        );
     }
 
     public function testSpanNameUpdate()


### PR DESCRIPTION
Use `NoopSpan` as the root of new traces, fix any unit tests and tested export to Zipkin and Jaeger.